### PR TITLE
Update templ.sublime-syntax to support Go component and  `for`/`if` c…

### DIFF
--- a/templ.sublime-syntax
+++ b/templ.sublime-syntax
@@ -4,7 +4,7 @@ name: Templ
 file_extensions: [templ]
 scope: source.go.templ
 extends: Packages/Go/Go.sublime-syntax
-version: 2
+version: 2.1
 
 contexts:
   prototype:
@@ -29,25 +29,58 @@ contexts:
     - match: '{{'
       scope: punctuation.section.embedded.begin.go
       push: go-embedded
+    - match: '^\s*(if|else|for|switch|case|default)\b'
+      scope: keyword.control.go
+      push: go-control-flow
     - match: '{'
       scope: punctuation.section.embedded.begin.go
       push: go-embedded
     - match: '@'
       scope: punctuation.section.embedded.begin.go
-      push: go-embedded
+      push: go-at-embedded
 
   go-embedded:
     - meta_scope: source.go.embedded
+    - match: '{'
+      push: go-embedded
     - include: pop-go
     - include: Packages/Go/Go.sublime-syntax
+
+  go-control-flow:
+    - meta_scope: source.go.embedded
+    - match: '\{(?=\s*(<|$))'
+      scope: punctuation.section.embedded.begin.go
+      set: templ-block
+    - match: '\{'
+      push: go-embedded
+    - include: Packages/Go/Go.sublime-syntax
+
+  go-at-embedded:
+    - meta_scope: source.go.embedded
+    - match: '\{(?=\s*(<|$))'
+      scope: punctuation.section.embedded.begin.go
+      set: templ-block
+    - match: '\{'
+      push: go-embedded
+    - match: '(?=\s*<)'
+      pop: true
+    - match: '$'
+      pop: true
+    - include: pop-go
+    - include: Packages/Go/Go.sublime-syntax
+
+  templ-block:
+    - meta_scope: meta.templ.block
+      scope: text.html.basic
+    - include: templ-content
+    - match: '\}'
+      scope: punctuation.section.embedded.end.go
+      pop: true
 
   pop-go:
     - match: '}}'
       scope: punctuation.section.embedded.end.go
       pop: true
     - match: '}'
-      scope: punctuation.section.embedded.end.go
-      pop: true
-    - match: '{' # for the @
       scope: punctuation.section.embedded.end.go
       pop: true


### PR DESCRIPTION
…alls

Summary
   Improved the templ.sublime-syntax definition to correctly handle @ component calls and Go control flow statements like for and if that contain nested curly braces.

   Changes
   • Fix for @Component Calls: Resolved a bug where calling a component without a block e.g., @Icon(...) would fail to return to HTML mode, breaking highlighting for the rest of the file.
   • Recursive Brace Matching: Implemented robust brace tracking for Go expressions. This ensures that Go code containing curly braces—such as map literals map[string]string{"a": "b"} or slice literals
   []string{"a"}—no longer prematurely exits the Go context.
   • Enhanced Control Flow Support: Added explicit support for Go keywords if, else, for, switch, case, default within templ files.
   • Block Start Heuristics: Added a lookahead pattern \{(?=\s*(<|$)) to accurately distinguish between the start of a templ block which contains HTML and standard Go blocks, ensuring stable transitions
   between Go logic and embedded HTML.
   • Context Unification: Introduced a templ-block context to consistently manage the transition between Go-heavy regions and the underlying HTML structure.